### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ iosViews
 
 Sketch plugin to generate ios view code
 
-###pathExporter.sketchplugin (finally fixed)
+### pathExporter.sketchplugin (finally fixed)
 exports your views as UIBezierPath as swift code
 so you'll have something like
 
@@ -11,7 +11,7 @@ so you'll have something like
     path.moveToPoint(...)
     ...
 
-####Why?
+#### Why?
 It's very annoying to draw in ios in code. But it's annoying to draw in sketch and export it as a picture because you can no longer use the CGRect dimensions from ios. You're stuck with whatever dimensions you picked in sketch.
 
 This will generate a bunch of swift functions, with 1 main function which takes in a CGRect so you can put it in layoutSubviews. All your shapes will be relative to how you depict them in sketch and the CGRect. Also you can edit the code and add your own transformations or animations, instead of having to create a ton of assets and load them dynamically.
@@ -21,7 +21,7 @@ For instance, if in sketch you offset your creation 20px from the left, and your
 When you run the plugin it puts the generated code into your artboard, so if you have a very complex shape (or groups of shapes) pasting the code might be slow or even crash sketch. If it is complex and hasn't crashed, it might take minutes (spinning beachball) but it will work.
 
 
-####How does it work?
+#### How does it work?
 1. create an artboard (let's say iphone sized)
 1. create some shape you want that you'd have to do in code otherwise
 1. select the artboard (make sure it's only the artboard, this is very important)
@@ -31,7 +31,7 @@ When you run the plugin it puts the generated code into your artboard, so if you
   - you will get code where everything is relative to the artboard
   - NOTE: for complex shapes the export might be slow (take minutes)
 
-####Unfortunatelly this doesn't work with:
+#### Unfortunatelly this doesn't work with:
 1. boolean operations (union, subtract, intersect, difference)
 1. radius on object (set the radius on individual path instead of object... click enter > highlight points > set radius)
 1. opacity on object (set your opacity on the color directly, and it will work)
@@ -48,16 +48,16 @@ When you run the plugin it puts the generated code into your artboard, so if you
 1. even/odd setting on fill is ignored (it uses whatever ios uses, I don't know if it's even/odd or non zero by default)
 1. border arrow settings
 
-####TODO:
+#### TODO:
 - fix a lot of the things that don't work
 - settle on a good shortcut
 - add this to sketch toolbox
 
-####Example
-#####Sketch File
+#### Example
+##### Sketch File
 ![moo png](https://github.com/Charimon/iosViews/blob/master/moo_sketch.png?raw=true "moo_sketch.png")
 
-#####Generated Code
+##### Generated Code
 ```swift
 lazy var outline: CAShapeLayer = {
   let l = CAShapeLayer()
@@ -101,7 +101,7 @@ func moo(bounds: CGRect) {
 ```
 [full swift file](../moo.swift)
 
-#####ios
+##### ios
 after adding the following to some UIView
 ```swift
 override func layoutSubviews() {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
